### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To get stared, check out [http://xpressengine.github.io/XEIcon](http://xpresseng
 - [Download the latest release](https://github.com/xpressengine/XEIcon/archive/master.zip).
 - Clone the repo: `git clone https://github.com/xpressengine/XEIcon.git`.
 - Install with [Bower](http://bower.io): `bower install xeicon`.
-- CDN by [jsDelivr](http://www.jsdelivr.com/#!xeicon): `<link rel="stylesheet" href="//cdn.jsdelivr.net/xeicon/2/xeicon.min.css">`
+- CDN by [jsDelivr](http://www.jsdelivr.com/#!xeicon): `<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/xeicon@2/xeicon.min.css">`
 
 - Install with [Bower](http://bower.io): 
 ```


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.
I updated the link now so you don't forget to do it when you release a new version.

Feel free to ping me if you have any questions regarding this change.