### PR TITLE
Update jsDelivr links

### DIFF
--- a/started.html
+++ b/started.html
@@ -78,7 +78,7 @@
                     <li>
                         <p class="desc-txt">1. 사이트 <span class="deco-box">&lt;head&gt;</span> 태그 안에 아래의 코드를 붙입니다.</p>
                         <div class="desc-code-box">
-                            <p class="desc-code"><code>&lt;link rel=&quot;stylesheet&quot; href=&quot;//cdn.jsdelivr.net/gh/xpressengine/xeicon@2.3.3/xeicon.min.css&quot;&gt;</code></p>
+                            <p class="desc-code"><code>&lt;link rel=&quot;stylesheet&quot; href=&quot;//cdn.jsdelivr.net/npm/xeicon@2.3.3/xeicon.min.css&quot;&gt;</code></p>
                         </div>
                     </li>
                     <li>
@@ -91,7 +91,7 @@
                     <li>
                         <p class="desc-txt">1. Paste the following code into the <span class="deco-box">&lt;head&gt;</span> section of your site&rsquo;s HTML.</p>
                         <div class="desc-code-box">
-                            <p class="desc-code"><code>&lt;link rel=&quot;stylesheet&quot; href=&quot;//cdn.jsdelivr.net/gh/xpressengine/xeicon@2.3.3/xeicon.min.css&quot;&gt;</code></p>
+                            <p class="desc-code"><code>&lt;link rel=&quot;stylesheet&quot; href=&quot;//cdn.jsdelivr.net/npm/xeicon@2.3.3/xeicon.min.css&quot;&gt;</code></p>
                         </div>
                     </li>
                     <li>


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

While our new back-end supports serving files from both npm and GitHub, we recommend always using only one of these methods for every package, with npm being the preferred one (using only npm means you can get detailed package usage statistics and npm packages are also searchable on our website).

I updated the link to use npm instead of GitHub.

Feel free to ping me if you have any questions regarding this change.